### PR TITLE
修复 PokePlate 插件因 FIPixelmon 自定义宝可梦崩溃问题

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ allprojects {
     apply plugin: 'java'
 
     group = 'com.aiyostudio.pokeplate'
-    version = '2.1.2-BETA'
+    version = '2.1.3-BETA'
     archivesBaseName = "PokePlate"
 
     sourceCompatibility = targetCompatibility = '1.8'

--- a/module/pixelmon-1_12/src/main/java/com/aiyostudio/pokeplate/module/v1_12/PokemonModuleImpl.java
+++ b/module/pixelmon-1_12/src/main/java/com/aiyostudio/pokeplate/module/v1_12/PokemonModuleImpl.java
@@ -29,11 +29,13 @@ public class PokemonModuleImpl implements IPokemonModule {
 
     public PokemonModuleImpl() {
         for (EnumSpecies species : EnumSpecies.values()) {
-            Pokemon pokemon = Pixelmon.pokemonFactory.create(species);
-            String key = String.valueOf(com.mc9y.pokestar.Main.getPokeStarAPI().getPokemonStar(species.name()));
-            DataContainer.PHOTO_ITEMS.put(species.name(), PokemonAPI.getInstance().getSpriteHelper().getSpriteItem(pokemon));
-            DataContainer.SPECIES_MAP.putIfAbsent(key, Lists.newArrayList(species.name));
-            DataContainer.SPECIES_MAP.get(key).add(species.name());
+            try {
+                Pokemon pokemon = Pixelmon.pokemonFactory.create(species);
+                String key = String.valueOf(com.mc9y.pokestar.Main.getPokeStarAPI().getPokemonStar(species.name()));
+                DataContainer.PHOTO_ITEMS.put(species.name(), PokemonAPI.getInstance().getSpriteHelper().getSpriteItem(pokemon));
+                DataContainer.SPECIES_MAP.putIfAbsent(key, Lists.newArrayList(species.name));
+                DataContainer.SPECIES_MAP.get(key).add(species.name());
+            } catch (ArrayIndexOutOfBoundsException ignored) {}
         }
         Bukkit.getPluginManager().registerEvents(new ForgeListener(), PokePlate.getInstance());
     }
@@ -67,8 +69,10 @@ public class PokemonModuleImpl implements IPokemonModule {
             return false;
         }
         if (params.length > 3 && "true".equalsIgnoreCase(params[3])) {
-            Pokemon pokemon = Pixelmon.pokemonFactory.create(specie);
-            Pixelmon.storageManager.getParty(player.getUniqueId()).add(pokemon);
+            try {
+                Pokemon pokemon = Pixelmon.pokemonFactory.create(specie);
+                Pixelmon.storageManager.getParty(player.getUniqueId()).add(pokemon);
+            } catch (ArrayIndexOutOfBoundsException ignored) {}
         } else {
             PlateApi.addPokedex(player, specie.name());
         }


### PR DESCRIPTION
在 Minecraft 1.12.2 使用 FIPixelmon-1.3.1(ForgeMod) 时，FIPixelmon 自定义宝可梦
在 Pixelmon.pokemonFactory.create() 中通过 EnumSpecies.values() 遍历时
可能抛出 ArrayIndexOutOfBoundsException，导致 PokePlate 插件无法运行。

在 PokemonModuleImpl（第32行和第72行）添加 try-catch 处理，遇到
异常的 FIPixelmon 宝可梦直接跳过，提高插件健壮性。

插件版本从 2.1.2-BETA 更新为 2.1.3-BETA。